### PR TITLE
Code cleanup and api function format for Group

### DIFF
--- a/mysite/mailing_list/admin.py
+++ b/mysite/mailing_list/admin.py
@@ -6,9 +6,6 @@ from .models import MailingList
 class MailingListAdmin(admin.ModelAdmin):
     list_display = ('name',)
 
-    def add(self, request):
-        pass
-
     def get_form(self, request, obj=None, **kwargs):
         form = super(MailingListAdmin, self).get_form(request, obj, **kwargs)
         form.current_user = request.user

--- a/mysite/mailing_list/models.py
+++ b/mysite/mailing_list/models.py
@@ -2,12 +2,11 @@ import httplib2
 
 from django.db import models
 from django.forms import ModelForm
+from django.http import HttpResponseRedirect
 from googleapiclient.discovery import build
 from django.contrib.auth.models import User
 from oauth2client.django_orm import CredentialsField
 from oauth2client.django_orm import Storage
-
-from mysite.utils import make_request
 
 
 class CredentialsModel(models.Model):
@@ -21,10 +20,6 @@ class MailingList(models.Model):
     email = models.CharField(max_length=200, blank=False)
     user = models.ForeignKey(User)
 
-    def __init__(self, *args, **kwargs):
-        self.request = kwargs.pop('request', None)
-        super(MailingList, self).__init__(*args, **kwargs)
-
     def __unicode__(self):
         return self.name
 
@@ -36,20 +31,50 @@ class MailingList(models.Model):
         return super(MailingList, self).save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
-        scope = '/admin/directory/v1/groups/{}'.format(self.email)
-        make_request('DELETE', 'www.googleapis.com', scope)
-        return super(MailingList, self).delete(*args, **kwargs)
+        storage = Storage(CredentialsModel, 'id', self.user, 'credential')
+        credential = storage.get()
+
+        # TODO send them to the login page
+        if credential is None or credential.invalid is True:
+            return
+
+        http = credential.authorize(httplib2.Http())
+        service = build('admin', 'directory_v1', http=http)
+        delete = service.groups().delete(groupKey=self.email)
+
+        # if the token is out of date, make the user login again
+        try:
+            return delete.execute()
+        except:
+            HttpResponseRedirect('/accounts/login/')
 
     def update(self, *args, **kwargs):
-        scope = '/admin/directory/v1/groups/{}'.format(self.email)
-        make_request('PUT', 'www.googleapis.com', scope)
-        return super(MailingList, self).delete(*args, **kwargs)
+        storage = Storage(CredentialsModel, 'id', self.user, 'credential')
+        credential = storage.get()
+
+        # TODO send them to the login page
+        if credential is None or credential.invalid is True:
+            return
+
+        post_data = {
+            'email': self.email,
+            'name': self.name
+        }
+
+        http = credential.authorize(httplib2.Http())
+        service = build('admin', 'directory_v1', http=http)
+        create = service.groups().patch(body=post_data, groupKey=self.email)
+
+        # if the token is out of date, make the user login again
+        try:
+            return create.execute()
+        except:
+            HttpResponseRedirect('/accounts/login/')
 
     def _make_mailing_list(self):
         # fetch the user's credentials created from `/accounts/login/`
         storage = Storage(CredentialsModel, 'id', self.user, 'credential')
         credential = storage.get()
-        import ipdb; ipdb.set_trace()
 
         # TODO send them to the login page
         if credential is None or credential.invalid is True:
@@ -63,8 +88,11 @@ class MailingList(models.Model):
         service = build('admin', 'directory_v1', http=http)
         create = service.groups().insert(body=post_data)
 
-        # should return the API response
-        return create.execute()
+        # if the token is out of date, make the user login again
+        try:
+            return create.execute()
+        except:
+            HttpResponseRedirect('/accounts/login/')
 
     class Meta:
         ordering = ('name',)

--- a/mysite/mailing_list/models.py
+++ b/mysite/mailing_list/models.py
@@ -44,9 +44,10 @@ class MailingList(models.Model):
 
         # if the token is out of date, make the user login again
         try:
-            return delete.execute()
+            delete.execute()
         except:
-            HttpResponseRedirect('/accounts/login/')
+            return HttpResponseRedirect('/accounts/login/')
+        return super(MailingList, self).delete(*args, **kwargs)
 
     def update(self, *args, **kwargs):
         storage = Storage(CredentialsModel, 'id', self.user, 'credential')
@@ -67,9 +68,10 @@ class MailingList(models.Model):
 
         # if the token is out of date, make the user login again
         try:
-            return create.execute()
+            create.execute()
         except:
-            HttpResponseRedirect('/accounts/login/')
+            return HttpResponseRedirect('/accounts/login/')
+        return super(MailingList, self).delete(*args, **kwargs)
 
     def _make_mailing_list(self):
         # fetch the user's credentials created from `/accounts/login/`

--- a/mysite/mailing_list/views.py
+++ b/mysite/mailing_list/views.py
@@ -1,11 +1,7 @@
 import os
-import logging
-import httplib2
 
-from apiclient.discovery import build
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponseBadRequest
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from oauth2client import xsrfutil
 from oauth2client.client import flow_from_clientsecrets
 from oauth2client.django_orm import Storage
@@ -30,7 +26,7 @@ def index(request):
     storage = Storage(CredentialsModel, 'id', request.user, 'credential')
     credential = storage.get()
 
-    if credential is None or credential.invalid is True:
+    if credential is None or credential.invalid:
         FLOW.params['state'] = xsrfutil.generate_token(SECRET_KEY,
                                                        str(request.user))
         authorize_url = FLOW.step1_get_authorize_url()


### PR DESCRIPTION
All of the `POST`, `PATCH`, and `DELETE` calls to the google groups api do not throw errors. They also all use the service method instead of the raw http request. These changes are still not showing in the admin
console. This needs to be investigated.

Hypothetically, any authorized, logged in superuser should be able to create, update, and destroy a google group and mailing list with the way the code is currently implemented
